### PR TITLE
Fixed the test code

### DIFF
--- a/test/calx.test.tsx
+++ b/test/calx.test.tsx
@@ -86,9 +86,9 @@ describe('viewOfInterval()', () => {
   it('returns a month interval for month view', () => {
     const datetime = DateTime.fromObject({ year: 2019, month: 12, day: 30 });
     const interval = viewOfInterval(datetime, 'months');
-    expect(numUnit(interval, 'days')).toBe(31);
+    expect(numUnit(interval, 'days')).toBe(42);
     expect(interval.start.day).toBe(1);
-    expect(interval.end.day).toBe(31);
+    expect(interval.end.day).toBe(11);
   });
   it('returns a year interval for year view', () => {
     const datetime = DateTime.fromObject({ year: 2019, month: 12, day: 30 });
@@ -107,7 +107,7 @@ describe('viewOfDays()', () => {
   it('returns day intervals for view and datetime', () => {
     const datetime = DateTime.fromObject({ year: 2019, month: 12, day: 30 });
     const days = viewOfDays(datetime, 'month');
-    expect(days.length).toBe(31);
+    expect(days.length).toBe(42);
     expect(days[0].start.day).toBe(1);
     expect(days[30].start.day).toBe(31);
   });

--- a/test/calx.test.tsx
+++ b/test/calx.test.tsx
@@ -83,12 +83,19 @@ describe('viewOfInterval()', () => {
     expect(interval.end.month).toBe(1);
     expect(interval.end.day).toBe(4);
   });
-  it('returns a month interval for month view', () => {
+  it('returns a month interval for month view (2019.12.30)', () => {
     const datetime = DateTime.fromObject({ year: 2019, month: 12, day: 30 });
     const interval = viewOfInterval(datetime, 'months');
     expect(numUnit(interval, 'days')).toBe(42);
     expect(interval.start.day).toBe(1);
     expect(interval.end.day).toBe(11);
+  });
+  it('returns a month interval for month view (2020.12.30)', () => {
+    const datetime = DateTime.fromObject({ year: 2020, month: 12, day: 30 });
+    const interval = viewOfInterval(datetime, 'months');
+    expect(numUnit(interval, 'days')).toBe(42);
+    expect(interval.start.day).toBe(29);
+    expect(interval.end.day).toBe(9);
   });
   it('returns a year interval for year view', () => {
     const datetime = DateTime.fromObject({ year: 2019, month: 12, day: 30 });


### PR DESCRIPTION
close #1 

The default number of days displayed by the month view is always 42 (7 * 6).
( "square" of days in the month )

https://github.com/hshoff/era/blob/cc261df3299cc8f17ec135b4fd77f9639396aba8/src/index.ts#L51

Added test code for December 30, 2020 for clarity.